### PR TITLE
Add description to pom (and metadata)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,10 @@
   <artifactId>quarkus-moneta-parent</artifactId>
   <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+  
   <name>Quarkus Moneta - Parent</name>
+  <description>Integrate JavaMoney (JSR 354) into Quarkus for JDK and native builds.</description>
+  
   <modules>
     <module>deployment</module>
     <module>runtime</module>


### PR DESCRIPTION
Fixes this :) 

<img width="398" alt="image" src="https://github.com/quarkiverse/quarkus-moneta/assets/11509290/e10e38e5-6893-44cc-b06d-9fcc1006c153">

So many extensions forget this, I wonder if it should be in the the list of things to do as part of https://github.com/quarkiverse/quarkiverse-devops/issues/231?