### PR TITLE
Drop useless -AlegacyConfigRoot=true

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -36,9 +36,6 @@
               <version>${quarkus.version}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -53,9 +53,6 @@
               <version>${quarkus.version}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
I would appreciate a quick merge as I'm trying to get a picture of which extensions actually need this compiler argument.

Thanks!